### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-NOTE: This license applies to Software and Code and does not apply to artwork or images related to this project.
-
 MIT License
 
 Copyright (c) 2017 Larva Labs


### PR DESCRIPTION
This is a PR to remove first line that excludes punks.png from the MIT license.

This will make the punks be more permissive and more decentralized, and in the spirit of open source and the permission-less nature of the Ethereum blockchain. 

I'm also open to other ideas. Inspired by this tweet https://twitter.com/punk4156/status/1462633772768272386